### PR TITLE
Rename plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# DASHICONS WordPress Plugin
+# FRONTEND DASHICONS WordPress Plugin
 
 Easily load the Dashicons icon font on the front-end of your site. If you've ever wanted to use this snazzy little icon font but your active theme doesn't load it on the front-end of your site for you, this plugin is here to save the day!
 
-Activate and you're ready to start using Dashicons on the front-end of your via HTML and CSS.
+Activate and you're ready to start using Dashicons icons on the front-end of your via HTML and CSS.
 
 **Important:** This plugin does not make any shortcodes available to implement Dashicons icons. You can easily use the HTML and CSS options to display icons following the official [Dashicons documentation](https://developer.wordpress.org/resource/dashicons/).
 
 ## Installation
 
-1. Install the Dashicons plugin either through your WordPress Plugins screen or by uploading the files to the /wp-content/plugins/ directory via FTP.
-2. Activate Dashicons in the Plugins screen of your WordPress admin.
-3. Begin using Dashicons through your site!
+1. Install the Frontend Dashicons plugin either through your WordPress Plugins screen or by uploading the files to the /wp-content/plugins/ directory via FTP.
+2. Activate Frontend Dashicons in the Plugins screen of your WordPress admin.
+3. Begin using Dashicons icons through your site!
 
 ## Support
 
-Please [open an issue](https://github.com/ericakfranz/dashicons/issues/new) for support.
+Please [open an issue](https://github.com/ericakfranz/frontend-dashicons/issues/new) for support.
 
 ## Contributing
 

--- a/frontend-dashicons.php
+++ b/frontend-dashicons.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: Dashicons
- * Plugin URI: https://fatpony.me/plugins/dashicons/
+ * Plugin Name: Frontend Dashicons
+ * Plugin URI: https://fatpony.me/plugins/frontend-dashicons-plugin/
  * Description: Load the Dashicons icon font on the front-end of your site.
  * Version: 1.0.0
  * Author: Erica Franz

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Dashicons ===
+=== Frontend Dashicons ===
 Contributors: ericakfranz
 Tags: dashicons
 Requires at least: 3.8
@@ -17,9 +17,9 @@ Activate and you’re ready to start using Dashicons on the front-end of your site
 **IMPORTANT:** This plugin does not make any shortcodes available to implement Dashicons icons. You can easily use the HTML and CSS options to display icons following the official Dashicons documentation at [https://developer.wordpress.org/resource/dashicons/](https://developer.wordpress.org/resource/dashicons/).
 
 == Installation ==
-1. Install the Dashicons plugin either through your WordPress Plugins screen or by uploading the files to your server via FTP.
-2. Activate Dashicons in the Plugins screen of your WordPress admin.
-3. Begin using Dashicons through your site!
+1. Install the Frontend Dashicons plugin either through your WordPress Plugins screen or by uploading the files to your server via FTP.
+2. Activate Frontend Dashicons in the Plugins screen of your WordPress admin.
+3. Begin using Dashicons icons through your site!
 
 == Frequently Asked Questions ==
 


### PR DESCRIPTION
As recommended during WordPress plugin repo submission review to comply with potential copyright issues; renaming plugin to resubmit to the plugin repository.
